### PR TITLE
If loadObject of the mySQL query is null(empty), several warning appear

### DIFF
--- a/admin/models/ContentObject.php
+++ b/admin/models/ContentObject.php
@@ -123,7 +123,7 @@ class ContentObject implements iJFTranslatable {
 			$row=null;
 			$row = $db->loadObject(  );
 			$this->id = $id;
-			$this->readFromRow( $row );
+			if(isset($row))	$this->readFromRow( $row );
 		}
 	}
 


### PR DESCRIPTION
If the loadObject of the mySQL query is null (empty), seen here, the call to $this->readFromRow  l to $this->readFromRow($row) at line 126 caused several warnings because object $row is not set.
